### PR TITLE
dosfstools: restore buildability with Android 4.4

### DIFF
--- a/dosfstools/src/mkfs.fat.c
+++ b/dosfstools/src/mkfs.fat.c
@@ -498,6 +498,8 @@ static uint64_t count_blocks(char *filename, int *remainder)
 
 static void check_mount(char *device_name)
 {
+/* older versions of Bionic don't have setmntent (4.x) or an incomplete impl (5.x) */
+#ifdef MOUNTED
     FILE *f;
     struct mntent *mnt;
 
@@ -507,6 +509,7 @@ static void check_mount(char *device_name)
 	if (strcmp(device_name, mnt->mnt_fsname) == 0)
 	    die("%s contains a mounted filesystem.");
     endmntent(f);
+#endif
 }
 
 /* Establish the geometry and media parameters for the device */


### PR DESCRIPTION
Bionic in Android 4.4 don't have setmntent

Change-Id: I8f9f03c084bd9c853b566fd94f6208566330cdc8
